### PR TITLE
Added pageObjectManager class to centralize page object creation and access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
-# Playwright
 node_modules/
-/blob-report/
-/playwright/.cache/
-
-# Playwright
+allure-report/
+allure-results/
 /test-results/
 /playwright-report/
+/blob-report/
+/playwright/.cache/
+state.json/
+playwright/.auth/
+package.json/
+package-lock.json/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "devDependencies": {
         "@playwright/test": "^1.54.2",
         "@types/node": "^24.1.0",
-        "allure-playwright": "^3.3.2"
+        "allure-commandline": "^2.34.1",
+        "allure-playwright": "^3.3.3",
+        "fs-extra": "^11.3.1"
       }
     },
     "node_modules/@playwright/test": {
@@ -39,17 +41,25 @@
         "undici-types": "~7.8.0"
       }
     },
-    "node_modules/allure-js-commons": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.3.2.tgz",
-      "integrity": "sha512-bBQW/G0Fas6Q+Ubixtk0OWP2Bywr1U5Mbei7paOezCPJpCZ47/xZvmUeuwBH0ekufi3ePCUHzDjXuwUK4iXZlg==",
+    "node_modules/allure-commandline": {
+      "version": "2.34.1",
+      "resolved": "https://registry.npmjs.org/allure-commandline/-/allure-commandline-2.34.1.tgz",
+      "integrity": "sha512-l42csZ2bz7FdtJI1t5zA3IXtOZ0YJaP/+JMRC9gt6aBHRVUIu+6r+3F7KRyshQ79osLz9/MHlGqAjBPRqH0QFw==",
       "dev": true,
-      "license": "Apache-2.0",
+      "bin": {
+        "allure": "bin/allure"
+      }
+    },
+    "node_modules/allure-js-commons": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.3.3.tgz",
+      "integrity": "sha512-MLkPWrVtrt/2TdAvaExNSM8yTuY/lEo+MSLoM2DOUUsWzbzki8XIxHoX+mSdkatZAJargsU9JeO/dL5kQyR5IQ==",
+      "dev": true,
       "dependencies": {
         "md5": "^2.3.0"
       },
       "peerDependencies": {
-        "allure-playwright": "3.3.2"
+        "allure-playwright": "3.3.3"
       },
       "peerDependenciesMeta": {
         "allure-playwright": {
@@ -58,13 +68,12 @@
       }
     },
     "node_modules/allure-playwright": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/allure-playwright/-/allure-playwright-3.3.2.tgz",
-      "integrity": "sha512-S0wyRdG17qQYSorp9Edz9c3DT6mcWwNE9noKdtfp2nmox5AHEVfdwQJx+IuroWUhSkLBRcZbD6E2+XayNIHCGA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/allure-playwright/-/allure-playwright-3.3.3.tgz",
+      "integrity": "sha512-f5+PsYJVBG9igcD2ldzRHOx4kMiuqyoezpneQd94R08I/S3lL/MvdMNmkT1vet8KYB8tsV1OuK17PZexnFaC+w==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "allure-js-commons": "3.3.2"
+        "allure-js-commons": "3.3.3"
       },
       "peerDependencies": {
         "@playwright/test": ">=1.36.0"
@@ -75,7 +84,6 @@
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
       }
@@ -85,9 +93,22 @@
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/fsevents": {
@@ -105,19 +126,35 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/md5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
       "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "charenc": "0.0.2",
         "crypt": "0.0.2",
@@ -162,6 +199,15 @@
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,14 @@
   "description": "A scalable and modular test automation framework built with Playwright. It follows the Page Object Model (POM) design, uses Gherkin syntax with Playwright Steps API, and supports custom fixtures and filters. Integrated with Allure for detailed reporting and Jenkins for automated CI/CD test execution.",
   "main": "index.js",
   "scripts": {
+    "playwright:ui": "node_modules\\.bin\\playwright test tests/specs --ui --project=chromium",
+    "playwright:ui:debug": "node_modules\\.bin\\playwright test tests/specs --debug --project=chromium",
     "playwright:run:login": "node_modules\\.bin\\playwright test tests/specs/login.spec.js --project=chromium",
-    "playwright:ui:login": "node_modules\\.bin\\playwright test tests/specs/login.spec.js --ui --project=chromium"
+    "playwright:run:regression": "node_modules\\.bin\\playwright test tests/specs/login.spec.js --grep @Regression --project=chromium",
+    "playwright:ui:login": "node_modules\\.bin\\playwright test tests/specs/login.spec.js --ui --project=chromium",
+    "show:report": "npx playwright show-report",
+    "generate-report": "node tests/support/utils/generate-allure-report.js",
+    "open-report": "node tests/support/utils/open-allure-report.js"
   },
   "keywords": [],
   "author": "",
@@ -14,6 +20,8 @@
   "devDependencies": {
     "@playwright/test": "^1.54.2",
     "@types/node": "^24.1.0",
-    "allure-playwright": "^3.3.2"
+    "allure-commandline": "^2.34.1",
+    "allure-playwright": "^3.3.3",
+    "fs-extra": "^11.3.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,5 +1,7 @@
 // @ts-check
 import { defineConfig, devices } from "@playwright/test";
+const path = require("path");
+const resolvePath = (...segments) => path.resolve(__dirname, ...segments);
 
 /**
  * Read environment variables from file.
@@ -17,8 +19,7 @@ export default defineConfig({
 
   testMatch: [
     "**/specs/*.js", // Regular test files
-    "**/*.setup.js", // Setup files
-    "**/specs/trials/*.js", // Trial files
+ 
   ],
   /* Run tests in files in parallel */
   fullyParallel: true,
@@ -29,7 +30,27 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  globalSetup: require.resolve(
+    resolvePath("tests", "support", "utils", "report-clean.js")
+  ),
+  reporter: [
+    ["list"],
+    [
+      "html",
+      {
+        outputFolder: "playwright-report",
+        open: "never",
+      },
+    ],
+    [
+      "allure-playwright",
+      {
+        outputFolder: "allure-results",
+        disableWebdriverStepsReporting: false,
+        disableWebdriverScreenshotsReporting: false,
+      },
+    ],
+  ],
 
   /* Configure projects for major browsers */
   projects: [
@@ -48,12 +69,26 @@ export default defineConfig({
 
     {
       name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
+      use: { ...devices["Desktop Firefox"],
+      baseURL: "https://cms.demo.katalon.com",
+      ignoreHTTPSErrors: true,
+      headless: true,
+      viewport: { width: 1920, height: 1080 },
+      trace: "on-first-retry",
+      timeout: 3000,
+      },
     },
 
     {
       name: "webkit",
-      use: { ...devices["Desktop Safari"] },
+      use: { ...devices["Desktop Safari"],
+      baseURL: "https://cms.demo.katalon.com",
+      ignoreHTTPSErrors: true,
+      headless: true,
+      viewport: { width: 1920, height: 1080 },
+      trace: "on-first-retry",
+      timeout: 3000,
+      },
     },
 
     /* Test against mobile viewports. */

--- a/tests/specs/login.spec.js
+++ b/tests/specs/login.spec.js
@@ -1,81 +1,106 @@
 // Import necessary Playwright test functions and custom modules
 const { test, expect } = require("@playwright/test");
-const { LoginPage } = require("../support/page-objects/loginPage.js"); // Page Object Model for login functionality
+const { pageObjectManager } = require("../support/utils/pageObjectManager"); // Page Object Model for login functionality
 const loginData = require("../fixtures/test-data/login-data.js"); // Test data for login scenarios
 
-let loginPage;
+let pageManager;
 
-// Grouping all login-related test cases
+// Grouping all loginPage.login-related test cases
 test.describe("User Authentication: Login Scenarios", () => {
-  // Setup before each test - instantiate the LoginPage object
+  // Setup before each test - instantiate the login object
   test.beforeEach(async ({ page }) => {
-    loginPage = new LoginPage(page);
+    pageManager = new pageObjectManager(page);
   });
 
   // Positive Test: Successful login with valid credentials
-  test("Verify that a user can log in successfully using a valid email and password", async ({ page }) => {
+  test("Verify that a user can log in successfully using a valid email and password", async ({
+    page,
+  }) => {
     await test.step("GIVEN I am on the login page", async () => {
-      await loginPage.gotoLoginPage();
+      await pageManager.loginPage().gotoLoginPage();
     });
 
-    await test.step("WHEN I enter valid credentials and click login", async () => {
-      await loginPage.login(loginData.validUser.email, loginData.validUser.password);
-      await loginPage.clickOnloginButton();
+    await test.step("WHEN I enter valid credentials", async () => {
+      await pageManager
+        .loginPage()
+        .login(loginData.validUser.email, loginData.validUser.password);
+    });
+
+    await test.step("AND I click on the login button", async () => {
+      await pageManager.loginPage().clickOnloginButton();
     });
 
     await test.step("THEN I should be redirected to the dashboard", async () => {
-      await expect(loginPage.logoutButton).toBeVisible(); // Validate user is logged in
+      await expect(pageManager.loginPage().logoutButton).toBeVisible(); // Validate user is logged in
       await expect(page).toHaveURL(loginData.verifyUrl(page).expectedUrl); // Check correct redirection
     });
   });
 
   // Negative Test: Incorrect credentials
-  test("Verify that the error message is shown when incorrect login credentials are entered", async ({ page }) => {
+  test("Verify that the error message is shown when incorrect login credentials are entered @Regression", async ({
+    page,
+  }) => {
     await test.step("GIVEN I am on the login page", async () => {
-      await loginPage.gotoLoginPage();
+      await pageManager.loginPage().gotoLoginPage();
     });
 
     await test.step("WHEN I enter invalid credentials and click login", async () => {
-      await loginPage.login(loginData.invalidUser.email, loginData.invalidUser.password);
-      await loginPage.clickOnloginButton();
+      await pageManager
+        .loginPage()
+        .login(loginData.invalidUser.email, loginData.invalidUser.password);
+      await pageManager.loginPage().clickOnloginButton();
     });
 
     await test.step("THEN I should see an error message", async () => {
-      await expect(loginPage.errorMessage).toContainText(loginData.errorMessage.invalidEmail); // Assert error message
+      await expect(pageManager.loginPage().errorMessage()).toContainText(
+        loginData.errorMessage.invalidEmail
+      ); // Assert error message
       await expect(page).toHaveURL(loginData.verifyUrl(page).expectedUrl); // Should remain on the same page
     });
   });
 
   // Negative Test: Empty email field
-  test("Verify that the system shows a validation message when the email field is left blank", async ({ page }) => {
+  test("Verify that the system shows a validation message when the email field is left blank @Regression", async ({
+    page,
+  }) => {
     await test.step("GIVEN I am on the login page", async () => {
-      await loginPage.gotoLoginPage();
+      await pageManager.loginPage().gotoLoginPage();
     });
 
     await test.step("WHEN I leave the email field empty and click login", async () => {
-      await loginPage.login(loginData.emptyEmail.email, loginData.emptyEmail.password);
-      await loginPage.clickOnloginButton();
+      await pageManager
+        .loginPage()
+        .login(loginData.emptyEmail.email, loginData.emptyEmail.password);
+      await pageManager.loginPage().clickOnloginButton();
     });
 
     await test.step("THEN I should see an email required error", async () => {
-      await expect(loginPage.errorMessage).toContainText(loginData.errorMessage.emptyEmail); // Assert validation message
+      await expect(pageManager.loginPage().errorMessage()).toContainText(
+        loginData.errorMessage.emptyEmail
+      ); // Assert validation message
       await expect(page).toHaveURL(loginData.verifyUrl(page).expectedUrl);
     });
   });
 
   // Negative Test: Empty password field
-  test("Verify that the system shows a validation message when the password field is left blank", async ({ page }) => {
+  test("Verify that the system shows a validation message when the password field is left blank", async ({
+    page,
+  }) => {
     await test.step("GIVEN I am on the login page", async () => {
-      await loginPage.gotoLoginPage();
+      await pageManager.loginPage().gotoLoginPage();
     });
 
     await test.step("WHEN I leave the password field empty and click login", async () => {
-      await loginPage.login(loginData.emptyPassword.email, loginData.emptyPassword.password);
-      await loginPage.clickOnloginButton();
+      await pageManager
+        .loginPage()
+        .login(loginData.emptyPassword.email, loginData.emptyPassword.password);
+      await pageManager.loginPage().clickOnloginButton();
     });
 
     await test.step("THEN I should see a password required error", async () => {
-      await expect(loginPage.errorMessage).toContainText(loginData.errorMessage.emptyPassword); // Assert validation message
+      await expect(pageManager.loginPage().errorMessage()).toContainText(
+        loginData.errorMessage.emptyPassword
+      ); // Assert validation message
       await expect(page).toHaveURL(loginData.verifyUrl(page).expectedUrl);
     });
   });

--- a/tests/support/page-objects/loginPage.js
+++ b/tests/support/page-objects/loginPage.js
@@ -2,7 +2,6 @@
 
 // Page Object Model for the Login Page
 class LoginPage {
-
   constructor(page) {
     this.page = page;
 
@@ -26,7 +25,7 @@ class LoginPage {
     this.logoutButton = page.locator('a:has-text("Logout")');
 
     // Locator for the error message container (shown on failed login)
-    this.errorMessage = page.locator(".woocommerce-error");
+    this.errorMessages = page.locator(".woocommerce-error");
 
     // Base URL retrieved from the Playwright context configuration
     this.baseUrl = page.context()._options.baseURL;
@@ -37,11 +36,7 @@ class LoginPage {
     await this.page.goto(`${this.baseUrl}/my-account/`);
   }
 
-  /**
-   * Fills in the login form with provided email and password, and checks "Remember Me"
-   * @param {string} email - User email/username
-   * @param {string} password - User password
-   */
+  //Fills in the login form with provided email and password, and checks "Remember Me"
   async login(email, password) {
     await this.usernameInput.fill(email);
     await this.passwordInput.fill(password);
@@ -51,6 +46,10 @@ class LoginPage {
   // Clicks the login button to submit the form
   async clickOnloginButton() {
     await this.loginButton.click();
+  }
+  // Clicks the login button to submit the form
+  errorMessage() {
+    return this.errorMessages;
   }
 }
 

--- a/tests/support/utils/generate-allure-report.js
+++ b/tests/support/utils/generate-allure-report.js
@@ -1,0 +1,31 @@
+// tests/support/utils/generate-allure-report.js
+const { exec } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const resolveFromRoot = (...segments) => path.resolve(process.cwd(), ...segments);
+const allureResultsDir = resolveFromRoot("allure-results");
+const allureReportDir = resolveFromRoot("allure-report");
+
+function logExists(label, dir) {
+    if (!fs.existsSync(dir)) {
+        console.warn(`⚠️  ${label} does not exist at: ${dir}`);
+    } else {
+        console.log(`✅ ${label} exists at: ${dir}`);
+    }
+}
+
+console.log("🔍 Checking directory existence...");
+logExists("Allure Results Directory", allureResultsDir);
+
+console.log("🚀 Generating Allure report...");
+const generateCmd = `npx allure generate "${allureResultsDir}" --clean -o "${allureReportDir}"`;
+
+exec(generateCmd, (err, stdout, stderr) => {
+    if (err) {
+        console.error(`❌ Error generating Allure report:\n${stderr}`);
+        process.exit(1);
+    }
+    console.log(stdout);
+    console.log("✅ Allure report generated successfully.");
+});

--- a/tests/support/utils/open-allure-report.js
+++ b/tests/support/utils/open-allure-report.js
@@ -1,0 +1,24 @@
+// tests/support/utils/open-allure-report.js
+const { exec } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const resolveFromRoot = (...segments) => path.resolve(process.cwd(), ...segments);
+const allureReportDir = resolveFromRoot("allure-report");
+
+if (!fs.existsSync(allureReportDir)) {
+    console.error(`❌ Allure report directory does not exist at: ${allureReportDir}`);
+    process.exit(1);
+}
+
+console.log("🖥️ Opening Allure report...");
+const openCmd = `npx allure open "${allureReportDir}"`;
+
+exec(openCmd, (err, stdout, stderr) => {
+    if (err) {
+        console.error(`❌ Error opening Allure report:\n${stderr}`);
+        process.exit(1);
+    }
+    console.log(stdout);
+    console.log("✅ Allure report opened successfully.");
+});

--- a/tests/support/utils/pageObjectManager.js
+++ b/tests/support/utils/pageObjectManager.js
@@ -1,0 +1,25 @@
+const { page } = require("@playwright/test");
+const { LoginPage } = require("../page-objects/loginPage.js");
+const { AddToCartPage } = require("../page-objects/addToCartPage.js");
+
+class pageObjectManager {
+  // Declare private fields
+ 
+  #loginPage;
+  #addToCartPage;
+
+  constructor(page) {
+    this.page = page;
+    this.#loginPage = new LoginPage(page);
+    this.#addToCartPage = new AddToCartPage(page);
+  }
+
+  loginPage() {
+    return this.#loginPage;
+  }
+
+  addToCartPage() {
+    return this.#addToCartPage;
+  }
+}
+module.exports = { pageObjectManager };

--- a/tests/support/utils/pageObjectManager.js
+++ b/tests/support/utils/pageObjectManager.js
@@ -2,24 +2,29 @@ const { page } = require("@playwright/test");
 const { LoginPage } = require("../page-objects/loginPage.js");
 const { AddToCartPage } = require("../page-objects/addToCartPage.js");
 
+// This class manages and provides access to all page objects.
+// It helps centralize page object creation and reuse them across tests.
 class pageObjectManager {
-  // Declare private fields
- 
+  // Declare private fields for encapsulating page object instances
   #loginPage;
   #addToCartPage;
 
+  // Constructor initializes all required page objects with the shared 'page' instance
   constructor(page) {
     this.page = page;
     this.#loginPage = new LoginPage(page);
     this.#addToCartPage = new AddToCartPage(page);
   }
 
+  // Returns the LoginPage object
   loginPage() {
     return this.#loginPage;
   }
 
+  // Returns the AddToCartPage object
   addToCartPage() {
     return this.#addToCartPage;
   }
 }
+
 module.exports = { pageObjectManager };

--- a/tests/support/utils/report-clean.js
+++ b/tests/support/utils/report-clean.js
@@ -1,0 +1,30 @@
+import { existsSync, remove } from 'fs-extra';
+import { join } from 'path';
+
+export default async () => {
+    // Use current working directory instead of relative path from this script
+    const projectRoot = process.cwd();
+    const allureResultsPath = join(projectRoot, 'allure-results');
+    const allureReportPath = join(projectRoot, 'allure-report');
+
+    try {
+        console.log('Cleaning up old allure folders...');
+        console.log(`Working directory: ${projectRoot}`);
+
+        if (existsSync(allureResultsPath)) {
+            await remove(allureResultsPath);
+            console.log('✅ Deleted: allure-results');
+        } else {
+            console.log('ℹ️ No allure-results folder found');
+        }
+
+        if (existsSync(allureReportPath)) {
+            await remove(allureReportPath);
+            console.log('✅ Deleted: allure-report');
+        } else {
+            console.log('ℹ️ No allure-report folder found');
+        }
+    } catch (err) {
+        console.error('❌ Error during cleanup:', err);
+    }
+};


### PR DESCRIPTION
This commit introduces a `pageObjectManager` class that helps organize and manage all the page objects used in our Playwright tests.

Instead of creating new instances of `LoginPage` or `AddToCartPage` manually in every test file, we now use this manager to access them. It stores private instances of each page object and returns them through dedicated methods like `loginPage()` and `addToCartPage()`.

This makes our test code cleaner, easier to maintain, and avoids repeating code.